### PR TITLE
Remove 'omeroweb' hard-coding.

### DIFF
--- a/virtualmicroscope/urls.py
+++ b/virtualmicroscope/urls.py
@@ -24,7 +24,7 @@
 #
 
 from django.conf.urls import patterns
-from omeroweb.virtualmicroscope import views
+from virtualmicroscope import views
 
 urlpatterns = patterns('',
 )


### PR DESCRIPTION
If "omeroweb" is present in the import, then it's required to
place the imported package into the correct subdirectory.
Other webapps have followed the idiom of using just their
own package name, which makes them pip installable or
easier.